### PR TITLE
Forced node alpine version & added Python in Dockerfile to fix install issue on building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:alpine
+FROM node:8.12-alpine
+RUN apk add g++ make python
 WORKDIR /src
 ADD ./backend /src/backend
 ADD ./client /src/client


### PR DESCRIPTION
Changed in Dockerfile base image from _node:alpine_ to _node:8.12-alpine_ and added python to docker image to fix #issue 39

This is a screenshot of the errors:
![building-image-error](https://user-images.githubusercontent.com/2039832/161132746-ab1d3058-982e-43bf-803a-e1fae3a97df4.png)

