### PR TITLE
pin base image, add python and docker dependencies into the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:alpine
+FROM node:8.12-alpine
+RUN apk add --update build-base docker g++ make python
 WORKDIR /src
 ADD ./backend /src/backend
 ADD ./client /src/client

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you don't have a docker compose, then you can use the following commands:
     ```
 - To run the image:
     ```
-    docker run -p 3230:3230 -v /usr/local/bin/docker:/usr/local/bin/docker -v /var/run/docker.sock:/var/run/docker.sock docker-web-gui
+    docker run -p 3230:3230 -v /var/run/docker.sock:/var/run/docker.sock docker-web-gui
     ```
 
 ### With Docker Compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,4 @@ services:
     ports:
       - "3230:3230"
     volumes:
-      - /usr/local/bin/docker:/usr/local/bin/docker 
       - /var/run/docker.sock:/var/run/docker.sock 


### PR DESCRIPTION
There is no use of the host's docker binary inside the alpine  image - it will nnot be runnable. Instead docker and python need to be added via apk.