### PR TITLE
🐞 Docker build fail due to old npm version and dependency issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:alpine
 WORKDIR /src
+RUN apk add --no-cache python3 py3-pip build-base
 ADD ./backend /src/backend
 ADD ./client /src/client
 ADD ./app.js /src/app.js


### PR DESCRIPTION
Resolved #50 

updated `Dockerfile`
```Dockerfile
FROM node:alpine
WORKDIR /src
RUN apk add --no-cache python3 py3-pip build-base
ADD ./backend /src/backend
ADD ./client /src/client
ADD ./app.js /src/app.js
RUN cd /src/backend && npm install --silent
CMD ["node", "/src/app.js"]
EXPOSE 3230
```