### PR TITLE
fix: allow to access api from another host than localhost

### DIFF
--- a/client/src/utilities/request.js
+++ b/client/src/utilities/request.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-export const restPath = 'http://localhost:3230/api/'
+export const restPath = '/api/'
 
 export const request = ( method, path, data = {} ) => {
   const options = {


### PR DESCRIPTION
I want to use this project on a server to monitor containers that I run on it, this allows to reach the api even when the host is not `localhost`.